### PR TITLE
게시판 & 게시글 해시태그의 순서를 입력 시 순서로 유지되도록 개선

### DIFF
--- a/src/main/java/site/board/boardtraining/domain/article/dto/api/CreateArticleRequest.java
+++ b/src/main/java/site/board/boardtraining/domain/article/dto/api/CreateArticleRequest.java
@@ -3,13 +3,13 @@ package site.board.boardtraining.domain.article.dto.api;
 import site.board.boardtraining.domain.article.constant.ArticleStatus;
 import site.board.boardtraining.domain.article.dto.business.CreateArticleDto;
 
-import java.util.Set;
+import java.util.LinkedHashSet;
 
 public record CreateArticleRequest(
         String title,
         String content,
         String thumbnailImageUrl,
-        Set<String> hashtags,
+        LinkedHashSet<String> hashtags,
         ArticleStatus status
 ) {
     public CreateArticleDto toDto(

--- a/src/main/java/site/board/boardtraining/domain/article/dto/api/UpdateArticleRequest.java
+++ b/src/main/java/site/board/boardtraining/domain/article/dto/api/UpdateArticleRequest.java
@@ -3,13 +3,13 @@ package site.board.boardtraining.domain.article.dto.api;
 import site.board.boardtraining.domain.article.constant.ArticleStatus;
 import site.board.boardtraining.domain.article.dto.business.UpdateArticleDto;
 
-import java.util.Set;
+import java.util.LinkedHashSet;
 
 public record UpdateArticleRequest(
         String title,
         String content,
         String thumbnailImageUrl,
-        Set<String> hashtags,
+        LinkedHashSet<String> hashtags,
         ArticleStatus status
 ) {
     public UpdateArticleDto toDto(

--- a/src/main/java/site/board/boardtraining/domain/article/dto/business/ArticleDto.java
+++ b/src/main/java/site/board/boardtraining/domain/article/dto/business/ArticleDto.java
@@ -4,14 +4,14 @@ import site.board.boardtraining.domain.article.entity.Article;
 import site.board.boardtraining.domain.member.dto.business.MemberDto;
 
 import java.time.LocalDateTime;
-import java.util.Set;
+import java.util.LinkedHashSet;
 
 public record ArticleDto(
         Long articleId,
         String title,
         String content,
         String thumbnailImageUrl,
-        Set<String> hashtags,
+        LinkedHashSet<String> hashtags,
         MemberDto member,
         LocalDateTime createdAt
 ) {
@@ -20,7 +20,7 @@ public record ArticleDto(
             String title,
             String content,
             String thumbnailImageUrl,
-            Set<String> hashtags,
+            LinkedHashSet<String> hashtags,
             MemberDto member,
             LocalDateTime createdAt
     ) {
@@ -37,7 +37,7 @@ public record ArticleDto(
 
     public static ArticleDto from(
             Article article,
-            Set<String> hashtags
+            LinkedHashSet<String> hashtags
     ) {
         return new ArticleDto(
                 article.getId(),

--- a/src/main/java/site/board/boardtraining/domain/article/dto/business/CreateArticleDto.java
+++ b/src/main/java/site/board/boardtraining/domain/article/dto/business/CreateArticleDto.java
@@ -5,13 +5,13 @@ import site.board.boardtraining.domain.article.entity.Article;
 import site.board.boardtraining.domain.board.entity.Board;
 import site.board.boardtraining.domain.member.entity.Member;
 
-import java.util.Set;
+import java.util.LinkedHashSet;
 
 public record CreateArticleDto(
         String title,
         String content,
         String thumbnailImageUrl,
-        Set<String> hashtags,
+        LinkedHashSet<String> hashtags,
         ArticleStatus status,
         Long boardId,
         Long memberId
@@ -20,7 +20,7 @@ public record CreateArticleDto(
             String title,
             String content,
             String thumbnailImageUrl,
-            Set<String> hashtags,
+            LinkedHashSet<String> hashtags,
             ArticleStatus status,
             Long boardId,
             Long memberId

--- a/src/main/java/site/board/boardtraining/domain/article/dto/business/UpdateArticleDto.java
+++ b/src/main/java/site/board/boardtraining/domain/article/dto/business/UpdateArticleDto.java
@@ -2,14 +2,14 @@ package site.board.boardtraining.domain.article.dto.business;
 
 import site.board.boardtraining.domain.article.constant.ArticleStatus;
 
-import java.util.Set;
+import java.util.LinkedHashSet;
 
 public record UpdateArticleDto(
         Long articleId,
         String title,
         String content,
         String thumbnailImageUrl,
-        Set<String> hashtags,
+        LinkedHashSet<String> hashtags,
         ArticleStatus status,
         Long memberId
 ) {
@@ -18,7 +18,7 @@ public record UpdateArticleDto(
             String title,
             String content,
             String thumbnailImageUrl,
-            Set<String> hashtags,
+            LinkedHashSet<String> hashtags,
             ArticleStatus status,
             Long memberId
     ) {

--- a/src/main/java/site/board/boardtraining/domain/board/dto/api/CreateBoardRequest.java
+++ b/src/main/java/site/board/boardtraining/domain/board/dto/api/CreateBoardRequest.java
@@ -2,13 +2,13 @@ package site.board.boardtraining.domain.board.dto.api;
 
 import site.board.boardtraining.domain.board.dto.business.CreateBoardDto;
 
-import java.util.Set;
+import java.util.LinkedHashSet;
 
 public record CreateBoardRequest(
         String title,
         String description,
         String thumbnailImageUrl,
-        Set<String> hashtags
+        LinkedHashSet<String> hashtags
 ) {
     public CreateBoardDto toDto(
             Long memberId

--- a/src/main/java/site/board/boardtraining/domain/board/dto/api/UpdateBoardRequest.java
+++ b/src/main/java/site/board/boardtraining/domain/board/dto/api/UpdateBoardRequest.java
@@ -2,13 +2,13 @@ package site.board.boardtraining.domain.board.dto.api;
 
 import site.board.boardtraining.domain.board.dto.business.UpdateBoardDto;
 
-import java.util.Set;
+import java.util.LinkedHashSet;
 
 public record UpdateBoardRequest(
         String title,
         String description,
         String thumbnailImageUrl,
-        Set<String> hashtags
+        LinkedHashSet<String> hashtags
 ) {
     public UpdateBoardDto toDto(
             Long boardId,

--- a/src/main/java/site/board/boardtraining/domain/board/dto/business/BoardDto.java
+++ b/src/main/java/site/board/boardtraining/domain/board/dto/business/BoardDto.java
@@ -4,20 +4,20 @@ import site.board.boardtraining.domain.board.entity.Board;
 import site.board.boardtraining.domain.member.dto.business.MemberDto;
 
 import java.time.LocalDateTime;
-import java.util.Set;
+import java.util.LinkedHashSet;
 
 public record BoardDto(
         Long boardId,
         String title,
         String description,
         String thumbnailImageUrl,
-        Set<String> hashtags,
+        LinkedHashSet<String> hashtags,
         MemberDto memberDto,
         LocalDateTime createAt
 ) {
     public static BoardDto from(
             Board board,
-            Set<String> hashtags
+            LinkedHashSet<String> hashtags
     ) {
         return new BoardDto(
                 board.getId(),

--- a/src/main/java/site/board/boardtraining/domain/board/dto/business/CreateBoardDto.java
+++ b/src/main/java/site/board/boardtraining/domain/board/dto/business/CreateBoardDto.java
@@ -3,20 +3,20 @@ package site.board.boardtraining.domain.board.dto.business;
 import site.board.boardtraining.domain.board.entity.Board;
 import site.board.boardtraining.domain.member.entity.Member;
 
-import java.util.Set;
+import java.util.LinkedHashSet;
 
 public record CreateBoardDto(
         String title,
         String description,
         String thumbnailImageUrl,
-        Set<String> hashtags,
+        LinkedHashSet<String> hashtags,
         Long memberId
 ) {
     public static CreateBoardDto of(
             String title,
             String description,
             String thumbnailImageUrl,
-            Set<String> hashtags,
+            LinkedHashSet<String> hashtags,
             Long memberId
     ) {
         return new CreateBoardDto(

--- a/src/main/java/site/board/boardtraining/domain/board/dto/business/UpdateBoardDto.java
+++ b/src/main/java/site/board/boardtraining/domain/board/dto/business/UpdateBoardDto.java
@@ -1,13 +1,13 @@
 package site.board.boardtraining.domain.board.dto.business;
 
-import java.util.Set;
+import java.util.LinkedHashSet;
 
 public record UpdateBoardDto(
         Long boardId,
         String title,
         String description,
         String thumbnailImageUrl,
-        Set<String> hashtags,
+        LinkedHashSet<String> hashtags,
         Long memberId
 ) {
     public static UpdateBoardDto of(
@@ -15,7 +15,7 @@ public record UpdateBoardDto(
             String title,
             String description,
             String thumbnailImageUrl,
-            Set<String> hashtags,
+            LinkedHashSet<String> hashtags,
             Long memberId
     ) {
         return new UpdateBoardDto(

--- a/src/main/java/site/board/boardtraining/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/site/board/boardtraining/domain/hashtag/service/HashtagService.java
@@ -3,22 +3,22 @@ package site.board.boardtraining.domain.hashtag.service;
 import site.board.boardtraining.domain.article.entity.Article;
 import site.board.boardtraining.domain.board.entity.Board;
 
-import java.util.Set;
+import java.util.LinkedHashSet;
 
 public interface HashtagService {
-    Set<String> getAllBoardHashtags(Board board);
+    LinkedHashSet<String> getAllBoardHashtags(Board board);
 
-    void addBoardHashtags(Set<String> boardHashtags, Board board);
+    void addBoardHashtags(LinkedHashSet<String> boardHashtags, Board board);
 
-    void updateBoardHashtags(Set<String> boardHashtags, Board board);
+    void updateBoardHashtags(LinkedHashSet<String> boardHashtags, Board board);
 
     void deleteBoardHashtags(Board board);
 
-    Set<String> getAllArticleHashtags(Article article);
+    LinkedHashSet<String> getAllArticleHashtags(Article article);
 
-    void addArticleHashtags(Set<String> articleHashtags, Article article);
+    void addArticleHashtags(LinkedHashSet<String> articleHashtags, Article article);
 
-    void updateArticleHashtags(Set<String> articleHashtags, Article article);
+    void updateArticleHashtags(LinkedHashSet<String> articleHashtags, Article article);
 
     void deleteArticleHashtags(Article article);
 }

--- a/src/main/java/site/board/boardtraining/domain/hashtag/service/HashtagServiceImpl.java
+++ b/src/main/java/site/board/boardtraining/domain/hashtag/service/HashtagServiceImpl.java
@@ -11,7 +11,7 @@ import site.board.boardtraining.domain.hashtag.repository.ArticleHashtagReposito
 import site.board.boardtraining.domain.hashtag.repository.BoardHashtagRepository;
 import site.board.boardtraining.domain.hashtag.repository.HashtagRepository;
 
-import java.util.Set;
+import java.util.LinkedHashSet;
 import java.util.stream.Collectors;
 
 @Transactional
@@ -35,16 +35,16 @@ public class HashtagServiceImpl
 
     @Transactional(readOnly = true)
     @Override
-    public Set<String> getAllBoardHashtags(Board board) {
+    public LinkedHashSet<String> getAllBoardHashtags(Board board) {
         return boardHashtagRepository.findAllByBoard(board)
                 .stream()
                 .map(BoardHashtag::getHashtag)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection( LinkedHashSet::new ));
     }
 
     @Transactional(readOnly = true)
     @Override
-    public void addBoardHashtags(Set<String> boardHashtags, Board board) {
+    public void addBoardHashtags(LinkedHashSet<String> boardHashtags, Board board) {
         boardHashtags
                 .forEach(
                         hashtag -> {
@@ -62,7 +62,7 @@ public class HashtagServiceImpl
     }
 
     @Override
-    public void updateBoardHashtags(Set<String> boardHashtags, Board board) {
+    public void updateBoardHashtags(LinkedHashSet<String> boardHashtags, Board board) {
         deleteBoardHashtags(board);
         addBoardHashtags(boardHashtags, board);
     }
@@ -74,15 +74,15 @@ public class HashtagServiceImpl
 
     @Transactional(readOnly = true)
     @Override
-    public Set<String> getAllArticleHashtags(Article article) {
+    public LinkedHashSet<String> getAllArticleHashtags(Article article) {
         return articleHashtagRepository.findAllByArticle(article)
                 .stream()
                 .map(ArticleHashtag::getHashtag)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection( LinkedHashSet::new ));
     }
 
     @Override
-    public void addArticleHashtags(Set<String> articleHashtags, Article article) {
+    public void addArticleHashtags(LinkedHashSet<String> articleHashtags, Article article) {
         articleHashtags
                 .forEach(
                         hashtag -> {
@@ -100,7 +100,7 @@ public class HashtagServiceImpl
     }
 
     @Override
-    public void updateArticleHashtags(Set<String> articleHashtags, Article article) {
+    public void updateArticleHashtags(LinkedHashSet<String> articleHashtags, Article article) {
         deleteArticleHashtags(article);
         addArticleHashtags(articleHashtags, article);
     }


### PR DESCRIPTION
사용자가 입력한 순서대로 해시태그를 표시하기 위해 기존 Set<>자료형을 LinkedHashSet<>으로 변경하였다.

This closes #34 