### PR TITLE
키워드 + 해시태그 복합 검색 기능 추가

### DIFF
--- a/src/main/java/site/board/boardtraining/domain/article/controller/ArticleController.java
+++ b/src/main/java/site/board/boardtraining/domain/article/controller/ArticleController.java
@@ -19,6 +19,8 @@ import site.board.boardtraining.global.response.success.MultipleSuccessApiRespon
 import site.board.boardtraining.global.response.success.SingleSuccessApiResponse;
 import site.board.boardtraining.global.response.success.SuccessApiResponse;
 
+import java.util.LinkedHashSet;
+
 @RestController
 public class ArticleController {
     private final ArticleService articleService;
@@ -35,17 +37,19 @@ public class ArticleController {
     @GetMapping("/api/boards/{board-id}/articles")
     public ResponseEntity<MultipleSuccessApiResponse<ArticleDto>> searchArticles(
             @PathVariable("board-id") Long boardId,
-            @RequestParam(required = false) String searchKeyword,
-            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @RequestParam(value = "keyword", required = false, defaultValue = "") String searchKeyword,
+            @RequestParam(value = "tag", required = false, defaultValue = "") LinkedHashSet<String> hashtags,
+            @PageableDefault(size = 15, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         return ResponseEntity.ok(
                 MultipleSuccessApiResponse.of(
                         "성공적으로 게시글이 조회되었습니다.",
                         articleService.searchArticles(
                                 SearchArticlesDto.of(
-                                        pageable,
                                         boardId,
-                                        searchKeyword
+                                        searchKeyword,
+                                        hashtags,
+                                        pageable
                                 )
                         ).getContent()
                 )

--- a/src/main/java/site/board/boardtraining/domain/article/dto/business/SearchArticlesDto.java
+++ b/src/main/java/site/board/boardtraining/domain/article/dto/business/SearchArticlesDto.java
@@ -2,20 +2,25 @@ package site.board.boardtraining.domain.article.dto.business;
 
 import org.springframework.data.domain.Pageable;
 
+import java.util.Set;
+
 public record SearchArticlesDto(
-        Pageable pageable,
         Long boardId,
-        String searchKeyword
+        String searchKeyword,
+        Set<String> hashtags,
+        Pageable pageable
 ) {
     public static SearchArticlesDto of(
-            Pageable pageable,
             Long boardId,
-            String searchKeyword
+            String searchKeyword,
+            Set<String> hashtags,
+            Pageable pageable
     ) {
         return new SearchArticlesDto(
-                pageable,
                 boardId,
-                searchKeyword
+                searchKeyword,
+                hashtags,
+                pageable
         );
     }
 }

--- a/src/main/java/site/board/boardtraining/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/site/board/boardtraining/domain/article/repository/ArticleRepository.java
@@ -9,7 +9,8 @@ import site.board.boardtraining.domain.board.entity.Board;
 
 public interface ArticleRepository
         extends JpaRepository<Article, Long>,
-        QuerydslPredicateExecutor<Article> {
-
+        QuerydslPredicateExecutor<Article>,
+        ArticleRepositoryCustom
+{
     Page<Article> findByBoardAndTitleContainingOrContentContaining(Board board, String title, String content, Pageable pageable);
 }

--- a/src/main/java/site/board/boardtraining/domain/article/repository/ArticleRepositoryCustom.java
+++ b/src/main/java/site/board/boardtraining/domain/article/repository/ArticleRepositoryCustom.java
@@ -1,0 +1,16 @@
+package site.board.boardtraining.domain.article.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import site.board.boardtraining.domain.article.entity.Article;
+
+import java.util.Set;
+
+public interface ArticleRepositoryCustom {
+
+    Page<Article> searchArticlesByKeyword(String keyword, Pageable pageable);
+
+    Page<Article> searchArticlesByHashtag(Set<String> hashtags, Pageable pageable);
+
+    Page<Article> searchArticlesByKeywordAndHashtag(String keyword, Set<String> hashtags, Pageable pageable);
+}

--- a/src/main/java/site/board/boardtraining/domain/article/repository/ArticleRepositoryCustomImpl.java
+++ b/src/main/java/site/board/boardtraining/domain/article/repository/ArticleRepositoryCustomImpl.java
@@ -1,0 +1,84 @@
+package site.board.boardtraining.domain.article.repository;
+
+import com.querydsl.jpa.JPQLQuery;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import site.board.boardtraining.domain.article.entity.Article;
+import site.board.boardtraining.domain.article.entity.QArticle;
+import site.board.boardtraining.domain.hashtag.entity.QArticleHashtag;
+import site.board.boardtraining.domain.hashtag.entity.QHashtag;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+public class ArticleRepositoryCustomImpl
+        extends QuerydslRepositorySupport
+        implements ArticleRepositoryCustom {
+    public ArticleRepositoryCustomImpl() {
+        super(Article.class);
+    }
+
+    @Override
+    public Page<Article> searchArticlesByKeyword(
+            String keyword,
+            Pageable pageable
+    ) {
+        QArticle article = QArticle.article;
+
+        JPQLQuery<Article> query = from(article)
+                .where(
+                        article.title.containsIgnoreCase(keyword)
+                                .or(article.content.containsIgnoreCase(keyword))
+                )
+                .groupBy(article.id, article.createdAt);
+        List<Article> articles = Objects.requireNonNull(getQuerydsl()).applyPagination(pageable, query).fetch();
+
+        return new PageImpl<>(articles, pageable, query.fetchCount());
+    }
+
+    @Override
+    public Page<Article> searchArticlesByHashtag(
+            Set<String> hashtags,
+            Pageable pageable
+    ) {
+        QArticle article = QArticle.article;
+        QHashtag hashtag = QHashtag.hashtag;
+        QArticleHashtag articleHashtag = QArticleHashtag.articleHashtag;
+
+        JPQLQuery<Article> query = from(article)
+                .join(articleHashtag).on(article.id.eq(articleHashtag.article.id))
+                .join(hashtag).on(articleHashtag.hashtag.id.eq(hashtag.id))
+                .where(hashtag.title.in(hashtags))
+                .groupBy(article.id, article.createdAt);
+        List<Article> articles = Objects.requireNonNull(getQuerydsl()).applyPagination(pageable, query).fetch();
+
+        return new PageImpl<>(articles, pageable, query.fetchCount());
+    }
+
+    @Override
+    public Page<Article> searchArticlesByKeywordAndHashtag(
+            String keyword,
+            Set<String> hashtags,
+            Pageable pageable
+    ) {
+        QArticle article = QArticle.article;
+        QHashtag hashtag = QHashtag.hashtag;
+        QArticleHashtag articleHashtag = QArticleHashtag.articleHashtag;
+
+        JPQLQuery<Article> query = from(article)
+                .join(articleHashtag).on(article.id.eq(articleHashtag.article.id))
+                .join(hashtag).on(articleHashtag.hashtag.id.eq(hashtag.id))
+                .where(
+                        article.title.containsIgnoreCase(keyword)
+                                .or(article.content.containsIgnoreCase(keyword))
+                                .and(hashtag.title.in(hashtags))
+                )
+                .groupBy(article.id, article.createdAt);
+        List<Article> articles = Objects.requireNonNull(getQuerydsl()).applyPagination(pageable, query).fetch();
+
+        return new PageImpl<>(articles, pageable, query.fetchCount());
+    }
+}


### PR DESCRIPTION
QueryDSL을 활용하여 다양한 옵션의 검색 기능을 구현하였습니다.
- 키워드 검색
- 해시태그 검색
- 키워드 & 해시태그 복합 검색

정렬에 경우 지식의 부족으로 현재는 최신순 정렬로 고정하였고, 향 후 학습을 통해 좋아요 순, 댓글 많은 순 정렬을 구현할 예정입니다.

This closes #42 